### PR TITLE
Fix broken markup link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to **Engage**!
 
 The best way to get oriented is to head over to the [Engage Wiki](https://github.com/hackla-engage/Getting-Started-With-Engage/wiki), where you'll find information on product scope, wireframes, changelogs, and lots more.
 
-You can also check out [the current Engage prototype] on Heroku(https://engage-santa-monica.herokuapp.com/#/).
+You can also check out [the current Engage prototype](https://engage-santa-monica.herokuapp.com/#/) on Heroku.
 
 Finally, if you're ready to jump into the Slack conversation, join [the Hack for LA Workspace](https://hackforla-slack.herokuapp.com/) and find us in the **#engage** and **#engage-dev** channels.
 


### PR DESCRIPTION
Just noticed there was broken link markup in the README so I fixed it. :)